### PR TITLE
Fixing paths on Windows

### DIFF
--- a/src/libgit2-log-utils.coffee
+++ b/src/libgit2-log-utils.coffee
@@ -1,4 +1,3 @@
-
 ChildProcess = require "child_process"
 Path = require "path"
 Fs = require "fs"
@@ -92,6 +91,7 @@ module.exports = class Libgit2LogUtils
               resolve(historyEntries)
             else
               resolve _.filter historyEntries, (historyEntry) ->
+                projectRelativeFileOrDirectory = projectRelativeFileOrDirectory.replace(/\\/g, "/")
                 for file in historyEntry.files
                   return true if Bstr.startsWith(file.path, projectRelativeFileOrDirectory)
                 return false


### PR DESCRIPTION
On windows this if:
`if Bstr.startsWith(file.path, projectRelativeFileOrDirectory)`
was always false because on Windows paths has opposite slash character. Fixed it with simple replace.

Before this change only 2 of 4 test pass, with this fix all test pass on windows
